### PR TITLE
Term helpers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,9 +32,6 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Generate Next types
-        run: pnpm run typegen
-
       - name: Lint check
         run: pnpm run lint
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
     "format:check": "prettier --check \"**/*.{ts,tsx,js,jsx,mdx}\" --cache",
     "format:write": "prettier --write \"**/*.{ts,tsx,js,jsx,mdx}\" --cache",
     "postinstall": "prisma generate",
-    "typegen": "next typegen",
     "lint": "next lint",
     "lint:fix": "next lint --fix",
     "preview": "next build && next start",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -17,6 +17,7 @@ import { Separator } from "@/components/ui/separator";
 import { AppSidebar } from "@/components/app-sidebar";
 import { HeaderBreadcrumbs } from "@/components/header-breadcrumbs";
 import { ModeToggle } from "@/components/mode-toggle";
+import { TermProvider } from "@/components/term-combobox";
 
 export const metadata: Metadata = {
   title: "STS",
@@ -47,26 +48,28 @@ export default async function RootLayout({
           <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
             <Toaster richColors toastOptions={{ duration: 5000 }} />
             <TRPCReactProvider>
-              <SidebarProvider>
-                <AppSidebar user={session?.user} />
-                <SidebarInset>
-                  <header className="flex h-16 w-full shrink-0 items-center justify-between gap-2 transition-[width,height] ease-linear group-has-data-[collapsible=icon]/sidebar-wrapper:h-12">
-                    <div className="flex items-center gap-2 px-4">
-                      <SidebarTrigger className="-ml-1" />
-                      <Separator
-                        orientation="vertical"
-                        className="mr-2 data-[orientation=vertical]:h-4"
-                      />
-                      <HeaderBreadcrumbs />
-                    </div>
-                    <div className="px-2">
-                      <ModeToggle />
-                    </div>
-                  </header>
-                  <div className="flex flex-1 flex-col">{children}</div>
-                </SidebarInset>
-                <DevDock />
-              </SidebarProvider>
+              <TermProvider>
+                <SidebarProvider>
+                  <AppSidebar user={session?.user} />
+                  <SidebarInset>
+                    <header className="flex h-16 w-full shrink-0 items-center justify-between gap-2 transition-[width,height] ease-linear group-has-data-[collapsible=icon]/sidebar-wrapper:h-12">
+                      <div className="flex items-center gap-2 px-4">
+                        <SidebarTrigger className="-ml-1" />
+                        <Separator
+                          orientation="vertical"
+                          className="mr-2 data-[orientation=vertical]:h-4"
+                        />
+                        <HeaderBreadcrumbs />
+                      </div>
+                      <div className="px-2">
+                        <ModeToggle />
+                      </div>
+                    </header>
+                    <div className="flex flex-1 flex-col">{children}</div>
+                  </SidebarInset>
+                  <DevDock />
+                </SidebarProvider>
+              </TermProvider>
             </TRPCReactProvider>
           </ThemeProvider>
         </TooltipProvider>

--- a/src/components/term-combobox.tsx
+++ b/src/components/term-combobox.tsx
@@ -43,6 +43,7 @@ type TermContextValue = {
 
 const TermContext = createContext<TermContextValue | null>(null);
 
+// This wraps the whole app so you can call useTerm() anywhere
 export function TermProvider({ children }: { children: ReactNode }) {
   const [{ active, all }] = api.term.getTerms.useSuspenseQuery();
 

--- a/src/components/term-combobox.tsx
+++ b/src/components/term-combobox.tsx
@@ -104,7 +104,7 @@ function TermComboboxInternal() {
       <PopoverContent className="w-[200px] p-0">
         <Command>
           <CommandInput placeholder="Search terms..." className="h-9" />
-          <CommandList>
+          <CommandList className="max-h-64 overflow-y-auto">
             <CommandEmpty>No Terms found.</CommandEmpty>
             <CommandGroup>
               {all.map((term) => (

--- a/src/components/term-combobox.tsx
+++ b/src/components/term-combobox.tsx
@@ -110,11 +110,12 @@ function TermComboboxInternal() {
               {all.map((term) => (
                 <CommandItem
                   key={term.id}
-                  value={term.id}
-                  onSelect={(currentValue) => {
-                    setSelectedId(
-                      selectedId === currentValue ? null : currentValue,
-                    );
+                  value={term.label}
+                  onSelect={(label) => {
+                    const term = all.find((t) => t.label === label);
+                    if (!term) return;
+
+                    setSelectedId(term.id);
                     setOpen(false);
                   }}
                 >

--- a/src/components/term-combobox.tsx
+++ b/src/components/term-combobox.tsx
@@ -1,0 +1,145 @@
+"use client";
+
+import {
+  createContext,
+  Suspense,
+  useContext,
+  useMemo,
+  useState,
+  type ReactNode,
+} from "react";
+import { Check, ChevronsUpDown } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { Skeleton } from "./ui/skeleton";
+import { api, type RouterOutputs } from "@/trpc/react";
+import { Badge } from "./ui/badge";
+import { useSessionStorage } from "@/hooks/use-session-storage";
+
+type Term = RouterOutputs["term"]["getTerms"]["all"][number];
+type TermContextValue = {
+  all: Term[];
+  active: Term | null;
+  selectedId: string | null;
+  selectedTerm: Term | null;
+  setSelectedId: (id: string | null) => void;
+};
+
+const TermContext = createContext<TermContextValue | null>(null);
+
+export function TermProvider({ children }: { children: ReactNode }) {
+  const [{ active, all }] = api.term.getTerms.useSuspenseQuery();
+
+  const [selectedId, setSelectedId] = useSessionStorage<string | null>(
+    "sts:selectedTermId",
+    active?.id ?? null,
+  );
+
+  const selectedTerm = useMemo(
+    () => all.find((t) => t.id === selectedId) ?? null,
+    [all, selectedId],
+  );
+
+  const value = useMemo(
+    () => ({
+      all,
+      active,
+      selectedId,
+      selectedTerm,
+      setSelectedId,
+    }),
+    [all, active, selectedId, selectedTerm, setSelectedId],
+  );
+
+  return <TermContext.Provider value={value}>{children}</TermContext.Provider>;
+}
+
+export function useTerm() {
+  const ctx = useContext(TermContext);
+  if (!ctx) {
+    throw new Error("useTerm must be used within a TermProvider");
+  }
+  return ctx;
+}
+
+export function TermCombobox() {
+  return (
+    <Suspense fallback={<Skeleton className="h-9 w-[200px]" />}>
+      <TermComboboxInternal />
+    </Suspense>
+  );
+}
+
+function TermComboboxInternal() {
+  const { active, all, selectedId, selectedTerm, setSelectedId } = useTerm();
+  const [open, setOpen] = useState(false);
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          variant="outline"
+          role="combobox"
+          aria-expanded={open}
+          className="w-[200px] justify-between"
+        >
+          {selectedTerm ? selectedTerm.label : "Select term..."}
+          <ChevronsUpDown className="opacity-50" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-[200px] p-0">
+        <Command>
+          <CommandInput placeholder="Search terms..." className="h-9" />
+          <CommandList>
+            <CommandEmpty>No Terms found.</CommandEmpty>
+            <CommandGroup>
+              {all.map((term) => (
+                <CommandItem
+                  key={term.id}
+                  value={term.id}
+                  onSelect={(currentValue) => {
+                    setSelectedId(
+                      selectedId === currentValue ? null : currentValue,
+                    );
+                    setOpen(false);
+                  }}
+                >
+                  <div className="flex w-full items-center gap-2">
+                    <span>{term.label}</span>
+
+                    {term.id === active?.id && (
+                      <Badge className="font-sm px-1 py-0 leading-tight">
+                        Active
+                      </Badge>
+                    )}
+
+                    <Check
+                      className={cn(
+                        "ml-auto h-4 w-4",
+                        selectedId === term.id ? "opacity-100" : "opacity-0",
+                      )}
+                    />
+                  </div>
+                </CommandItem>
+              ))}
+            </CommandGroup>
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/src/hooks/use-session-storage.tsx
+++ b/src/hooks/use-session-storage.tsx
@@ -1,0 +1,146 @@
+import { useCallback, useEffect, useState } from "react";
+import type { Dispatch, SetStateAction } from "react";
+import { useEventCallback } from "./use-event-callback";
+import { useEventListener } from "./use-event-listener";
+
+declare global {
+  interface WindowEventMap {
+    "session-storage": CustomEvent;
+  }
+}
+
+type UseSessionStorageOptions<T> = {
+  serializer?: (value: T) => string;
+  deserializer?: (value: string) => T;
+  initializeWithValue?: boolean;
+};
+
+const IS_SERVER = typeof window === "undefined";
+
+export function useSessionStorage<T>(
+  key: string,
+  initialValue: T | (() => T),
+  options: UseSessionStorageOptions<T> = {},
+): [T, Dispatch<SetStateAction<T>>, () => void] {
+  const { initializeWithValue = true } = options;
+
+  const serializer = useCallback<(value: T) => string>(
+    (value) => {
+      if (options.serializer) {
+        return options.serializer(value);
+      }
+
+      return JSON.stringify(value);
+    },
+    [options],
+  );
+
+  const deserializer = useCallback<(value: string) => T>(
+    (value) => {
+      if (options.deserializer) {
+        return options.deserializer(value);
+      }
+      if (value === "undefined") {
+        return undefined as unknown as T;
+      }
+
+      const defaultValue =
+        initialValue instanceof Function ? initialValue() : initialValue;
+
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(value);
+      } catch (error) {
+        console.error("Error parsing JSON:", error);
+        return defaultValue;
+      }
+
+      return parsed as T;
+    },
+    [options, initialValue],
+  );
+
+  const readValue = useCallback((): T => {
+    const initialValueToUse =
+      initialValue instanceof Function ? initialValue() : initialValue;
+
+    if (IS_SERVER) {
+      return initialValueToUse;
+    }
+
+    try {
+      const raw = window.sessionStorage.getItem(key);
+      return raw ? deserializer(raw) : initialValueToUse;
+    } catch (error) {
+      console.warn(`Error reading sessionStorage key "${key}":`, error);
+      return initialValueToUse;
+    }
+  }, [initialValue, key, deserializer]);
+
+  const [storedValue, setStoredValue] = useState(() => {
+    if (initializeWithValue) {
+      return readValue();
+    }
+
+    return initialValue instanceof Function ? initialValue() : initialValue;
+  });
+
+  const setValue: Dispatch<SetStateAction<T>> = useEventCallback((value) => {
+    if (IS_SERVER) {
+      console.warn(
+        `Tried setting sessionStorage key "${key}" even though environment is not a client`,
+      );
+    }
+
+    try {
+      const newValue = value instanceof Function ? value(readValue()) : value;
+
+      window.sessionStorage.setItem(key, serializer(newValue));
+
+      setStoredValue(newValue);
+
+      window.dispatchEvent(new StorageEvent("session-storage", { key }));
+    } catch (error) {
+      console.warn(`Error setting sessionStorage key "${key}":`, error);
+    }
+  });
+
+  const removeValue = useEventCallback(() => {
+    if (IS_SERVER) {
+      console.warn(
+        `Tried removing sessionStorage key "${key}" even though environment is not a client`,
+      );
+    }
+
+    const defaultValue =
+      initialValue instanceof Function ? initialValue() : initialValue;
+
+    window.sessionStorage.removeItem(key);
+
+    setStoredValue(defaultValue);
+
+    window.dispatchEvent(new StorageEvent("session-storage", { key }));
+  });
+
+  useEffect(() => {
+    setStoredValue(readValue());
+  }, [key]);
+
+  const handleStorageChange = useCallback(
+    (event: StorageEvent | CustomEvent) => {
+      if ((event as StorageEvent).key && (event as StorageEvent).key !== key) {
+        return;
+      }
+      setStoredValue(readValue());
+    },
+    [key, readValue],
+  );
+
+  useEventListener("storage", handleStorageChange);
+
+  useEventListener("session-storage", handleStorageChange);
+
+  return [storedValue, setValue, removeValue];
+}
+
+export type { UseSessionStorageOptions };

--- a/src/server/api/root.ts
+++ b/src/server/api/root.ts
@@ -2,6 +2,7 @@ import { createCallerFactory, createTRPCRouter } from "@/server/api/trpc";
 import { excelRoute } from "./routers/excel";
 import { validateRoute } from "./routers/validate";
 import { exportRoute } from "./routers/export";
+import { termRoute } from "./routers/term";
 
 /**
  * This is the primary router for your server.
@@ -12,6 +13,7 @@ export const appRouter = createTRPCRouter({
   excel: excelRoute,
   validate: validateRoute,
   export: exportRoute,
+  term: termRoute,
 });
 
 // export type definition of API

--- a/src/server/api/routers/term.ts
+++ b/src/server/api/routers/term.ts
@@ -1,0 +1,28 @@
+import { createTRPCRouter, protectedProcedure } from "../trpc";
+
+export const termRoute = createTRPCRouter({
+  getTerms: protectedProcedure.query(async ({ ctx }) => {
+    const all = await ctx.db.term.findMany({
+      orderBy: [{ year: "desc" }, { termLetter: "desc" }],
+      select: { active: true, year: true, termLetter: true, id: true },
+    });
+
+    // combine year and term letter for convenience
+    const withLabel = all.map((t) => ({
+      ...t,
+      label: `${t.year} ${t.termLetter}`,
+    }));
+
+    // assuming only one active term at a time
+    const active = withLabel.find((t) => t.active) ?? null;
+
+    return { active, all: withLabel };
+  }),
+
+  getActive: protectedProcedure.query(async ({ ctx }) => {
+    return ctx.db.term.findFirst({
+      where: { active: true },
+      select: { active: true, year: true, termLetter: true, id: true },
+    });
+  }),
+});

--- a/src/server/api/routers/term.ts
+++ b/src/server/api/routers/term.ts
@@ -7,7 +7,7 @@ export const termRoute = createTRPCRouter({
       select: { active: true, year: true, termLetter: true, id: true },
     });
 
-    // combine year and term letter for convenience
+    // combine year and term letter into label field for convenience
     const withLabel = all.map((t) => ({
       ...t,
       label: `${t.year} ${t.termLetter}`,
@@ -20,6 +20,7 @@ export const termRoute = createTRPCRouter({
   }),
 
   getActive: protectedProcedure.query(async ({ ctx }) => {
+    // find first because only supposed to have one active term
     return ctx.db.term.findFirst({
       where: { active: true },
       select: { active: true, year: true, termLetter: true, id: true },


### PR DESCRIPTION
The whole app is now wrapped in with `<TermProvider />` so you can call `useTerm()` from anywhere in the app and be able to access all terms, the active term in the db, and the current selected term. 

The selected term defaults to the current active term. Selected term is stored in session storage, so it can survive page reloads, but gets reset back to the active term once the user closes the tab/browser. 

You can change the selected term with the provided `useTerm()` hook, which returns a function that takes in a `termId`. You can just also use the provided `<TermCombobox />` component, which is a popover combobox w/ search. 


Here is an example of using the `useTerm()` hook. You can also directly see how it is used in the `<TermCombobox />` component if you wish.

```tsx
"use client";

import { useTerm } from "@/components/term-combobox";

export function TermBadge() {
  const { selectedTerm, active } = useTerm();

  const termToShow = selectedTerm ?? active;

  if (!termToShow) return null;

  return (
    <span className="rounded-full bg-muted px-2 py-1 text-xs">
      {termToShow.label}
    </span>
  );
}
```